### PR TITLE
Avoid review status button

### DIFF
--- a/content.js
+++ b/content.js
@@ -4,7 +4,6 @@
 
 
 let observer = new MutationObserver((mutations) => {
-  // observer.disconnect();
   mutations.forEach((mutation) => {
     if (mutation.type === 'childList' &&
         mutation.target.localName === 'div' &&
@@ -35,8 +34,10 @@ let observer = new MutationObserver((mutations) => {
         head.appendChild(collapseButton);
       }
     }
-    observer.observe(document.getElementById('diffs'), {childList: true, subtree: true});
   });
 });
 
-observer.observe(document.getElementById('diffs'), {childList: true, subtree: true});
+let diffsDiv = document.getElementById('diffs');
+if (diffsDiv) {
+  observer.observe(diffsDiv, {childList: true, subtree: true});
+}

--- a/content.js
+++ b/content.js
@@ -2,17 +2,21 @@
 
 'use strict';
 
+const kButtonClass = 'reviewboard-collapse-add-on-collapse-button';
+const kButtonSelector = 'div.' + kButtonClass;
 
 let observer = new MutationObserver((mutations) => {
   mutations.forEach((mutation) => {
     if (mutation.type === 'childList' &&
-        mutation.target.localName === 'div' &&
-        mutation.target.className === 'diff-box') {
-      let tables =  mutation.target.querySelectorAll('table.sidebyside');
-      for (let table of tables) {
-        table.style.border = '1px solid rebeccapurple';
-        let head = table.querySelector('tr.filename-row > th');
-        let collapseButton = document.createElement('div');
+        mutation.target.matches && mutation.target.matches('div.diff-box') &&
+        // Avoid re-entering for our own button!
+        !Array.from(mutation.addedNodes).some(node => node.matches && node.matches(kButtonSelector))) {
+      let table =  mutation.target.querySelector('table.sidebyside');
+      table.style.border = '1px solid rebeccapurple';
+      let collapseButton = mutation.target.querySelector(kButtonSelector);
+      if (!collapseButton) {
+        collapseButton = document.createElement('div');
+        collapseButton.className = kButtonClass;
         collapseButton.textContent = 'Collapse';
         collapseButton.style.backgroundColor = '#a4a4a4';
         collapseButton.style.border = '1px solid #333';
@@ -30,8 +34,13 @@ let observer = new MutationObserver((mutations) => {
             body.classList.toggle('CodeMirror-vscrollbar');
           }
         });
+        mutation.target.appendChild(collapseButton);
+      }
 
-        head.appendChild(collapseButton);
+      let toggleReviewStatusButton =
+        Array.from(mutation.addedNodes).find(node => node.matches && node.matches('button.diff-file-btn'));
+      if (toggleReviewStatusButton) {
+        collapseButton.style.right = (20 + toggleReviewStatusButton.getBoundingClientRect().width) + "px";
       }
     }
   });


### PR DESCRIPTION
Some notes about what this is doing:

- not re-adding the mutation observer (because we're not removing it)
- not attempting to add the mutation observer on pages where we don't find the diffs container (like other mozreview pages) to avoid error spam in the console
- append buttons to the same parent as mozreview (ie the `<div class=diff-box>`)
- ignore our own addition in the mutation observer (because otherwise infinite loop fun ensues)
- don't add the button multiple times
- when the other button is added (only when logged in to reviewboard), reposition our button to avoid it.